### PR TITLE
Wrong number of parameters in string formatting

### DIFF
--- a/gpMgmt/bin/gpseginstall
+++ b/gpMgmt/bin/gpseginstall
@@ -705,7 +705,7 @@ def verifyVersionAtPath(usepath):
         items = pool.getCompletedItems()
         for i in items:
             if i.results.rc:
-                logger.error("error on host with command: %s" % (i.remoteHost, cmdStr))
+                logger.error("error on host %s with command: %s" % (i.remoteHost, cmdStr))
                 return True
             if not i.results.stdout:
                 logger.error("could not find version string from host %s with command: %s" % (i.remoteHost, cmdStr))


### PR DESCRIPTION
We should be more careful with string substitutions. The old code generates stack trace without giving out the information which host has the problem due to the bug in code
Zendesk ticket https://discuss.zendesk.com/agent/tickets/17783
